### PR TITLE
fix: prevent desktop nav overflow

### DIFF
--- a/src/components/BlogListPage.tsx
+++ b/src/components/BlogListPage.tsx
@@ -29,11 +29,11 @@ export default function BlogListPage({ posts, tags }: Readonly<BlogListPageProps
                         ? posts
                         : posts.filter((post) => post.data.tags.includes(selectedTag));
 
-        return (
-                <section className='mx-auto w-fit flex flex-col md:mx-4 xl:mx-32 2xl:mx-64'>
+       return (
+               <section className='flex w-full flex-col'>
                         <p className='italic text-end'>{filteredPosts.length} entries</p>
                         <hr className='block h-[1px] border-0 border-t mt-2 p-0 border-t-zinc-600' />
-                        <div className='mt-4 flex flex-wrap gap-2 justify-center max-w-5xl 2xl:max-w-6xl'>
+                       <div className='mt-4 flex flex-wrap gap-2 justify-center'>
                                 {tags.map((tag) => (
                                         <button
                                                 key={tag}
@@ -46,7 +46,7 @@ export default function BlogListPage({ posts, tags }: Readonly<BlogListPageProps
                                 ))}
                         </div>
                         <hr className='block h-[1px] border-0 border-t mt-2 mb-4 p-0 border-t-zinc-600' />
-                        <ul className='columns-1 lg:columns-2 2xl:columns-3 gap-6 md:gap-8 py-4 mt-4 max-w-5xl mx-auto'>
+                       <ul className='columns-1 lg:columns-2 2xl:columns-3 gap-6 md:gap-8 py-4 mt-4 w-full'>
                                 {filteredPosts.map((post) => (
                                         <li
                                                 key={post.data.title}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,7 +22,7 @@ import { BookText, Home, MicVocal, ScrollText, User } from 'lucide-astro';
 				></a
 			>
 		</h2>
-		<div class='flex gap-8 overflow-x-auto'>
+               <div class='flex gap-8 overflow-x-auto md:overflow-visible'>
 			<HeaderLink class='hidden md:flex' href='/'
 				><Home class='hidden lg:inline-block' />Home</HeaderLink
 			>

--- a/src/components/HeroCard.astro
+++ b/src/components/HeroCard.astro
@@ -7,20 +7,20 @@ const { image, url, title, description, isReverse = false } = Astro.props;
 <div
         class='border-2 border-[var(--accent)] rounded-xl flex-1 pointer bg-[color:var(--black-nav)] hover:bg-[color:var(--black)] hover:-translate-y-2 group transition-all duration-300 shadow-md hover:shadow-[0_0_15px_var(--accent)]'
 >
-	<a
-		class={`flex flex-col p-8 lg:p-12 gap-8 pointer items-center${isReverse ? ' 2xl:flex-row-reverse' : ' 2xl:flex-row'}`}
-		href={url}
-	>
+       <a
+               class={`flex w-full flex-col p-8 lg:p-12 gap-8 pointer items-center${isReverse ? ' 2xl:flex-row-reverse' : ' 2xl:flex-row'}`}
+               href={url}
+       >
                 <Image
                         class='flex-1 w-64 lg:w-72 h-64 lg:h-72 group-hover:scale-110 transition-transform duration-300 ease-in-out'
                         src={image}
                         alt={title}
                 />
-		<div class={`flex flex-col flex-3 items-center 2xl:items-start h-full${isReverse ? ' 2xl:items-end' : ''}`}>
-			<h1 class='text-2xl lg:text-4xl mb-8 font-bold'>{title}</h1>
-			<p class={`text-lg text-center xl:text-start lg:text-xl${isReverse ? ' 2xl:text-end' : ''}`}>
-				{description}
-			</p>
-		</div>
-	</a>
+               <div class={`flex w-full flex-col flex-3 items-center 2xl:items-start h-full${isReverse ? ' 2xl:items-end' : ''}`}>
+                       <h1 class='text-2xl lg:text-4xl mb-8 font-bold'>{title}</h1>
+                       <p class={`text-lg text-center xl:text-start lg:text-xl break-words hyphens-auto${isReverse ? ' 2xl:text-end' : ''}`}>
+                               {description}
+                       </p>
+               </div>
+       </a>
 </div>


### PR DESCRIPTION
## Summary
- avoid scrollbars on desktop navigation links
- wrap hero card text to prevent overflow
- expand blog list layout so content isn't squeezed

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68959ce341148325af17eb5d6a84b272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated blog list and tag button layouts to use full-width, fluid designs for improved responsiveness.
  * Adjusted navigation bar to enable horizontal scrolling only on small screens, displaying links fully on larger screens.
  * Enhanced hero card appearance with full-width layout and improved text wrapping and hyphenation for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->