### PR TITLE
feat: add abstract page headers

### DIFF
--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -1,0 +1,10 @@
+---
+const { title, subtitle } = Astro.props;
+---
+<section class="relative py-24 md:py-32 text-center overflow-hidden">
+  <div class="absolute inset-0 -z-10">
+    <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120%] h-[120%] bg-[conic-gradient(at_top_left,_var(--tw-gradient-stops))] from-indigo-500 via-purple-500 to-pink-500 opacity-30 blur-3xl animate-[spin_20s_linear_infinite]"></div>
+  </div>
+  <h1 class="text-5xl sm:text-6xl font-bold tracking-tight">{title}</h1>
+  <p class="mt-4 text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">{subtitle}</p>
+</section>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,55 +4,56 @@ import { Image } from 'astro:assets';
 import profileImage from '../assets/images/profile.jpg';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { Github, Instagram, Linkedin } from 'lucide-astro';
+import PageHeader from '../components/PageHeader.astro';
 ---
 
 <BaseLayout title={`${SITE_TITLE} - About`} description={SITE_DESCRIPTION}>
-    <section
-		class='mx-auto prose dark:prose-invert prose-a:text-[color:var(--accent)] hyphens-auto md:prose-lg'
-	>
-		<h1>About</h1>
-		<Image
-			src={profileImage}
-			alt="Pete's profile picture"
-			class='rounded-full w-48 h-48 mt-4 mx-auto'
-		/>
-		<div class='flex flex-wrap mx-auto w-4/5 justify-center gap-6'>
-			<a
-				class='hover:-translate-y-1 transition-transform duration-100 p-1'
-				href='https://github.com/Pittawat2542'
-				target='_blank'
-			>
-				<Github />
-			</a>
-			<a
-				class='hover:-translate-y-1 transition-transform duration-100 p-1'
-				href='https://www.linkedin.com/in/pittawat-tav/'
-				target='_blank'
-			>
-				<Linkedin />
-			</a>
-			<a
-				class='hover:-translate-y-1 transition-transform duration-100 p-1'
-				href='https://www.instagram.com/pete.pittawat/'
-				target='_blank'
-			>
-				<Instagram />
-			</a>
-			<a
-				class='hover:-translate-y-1 transition-transform duration-100 p-1'
-				href='https://scholar.google.co.jp/citations?user=2CFoP9cAAAAJ&hl=en'
-				target='_blank'
-			>
-				Google Scholar
-			</a>
-			<a
-				class='hover:-translate-y-1 transition-transform duration-100 p-1'
-				href='https://orcid.org/0000-0002-6824-2634'
-				target='_blank'
-			>
-				ORCID
-			</a>
-		</div>
+  <PageHeader title="About" subtitle="Learn more about me" />
+  <section
+    class='mx-auto prose dark:prose-invert prose-a:text-[color:var(--accent)] hyphens-auto md:prose-lg'
+  >
+    <Image
+      src={profileImage}
+      alt="Pete's profile picture"
+      class='rounded-full w-48 h-48 mt-4 mx-auto'
+    />
+    <div class='flex flex-wrap mx-auto w-4/5 justify-center gap-6'>
+      <a
+        class='hover:-translate-y-1 transition-transform duration-100 p-1'
+        href='https://github.com/Pittawat2542'
+        target='_blank'
+      >
+        <Github />
+      </a>
+      <a
+        class='hover:-translate-y-1 transition-transform duration-100 p-1'
+        href='https://www.linkedin.com/in/pittawat-tav/'
+        target='_blank'
+      >
+        <Linkedin />
+      </a>
+      <a
+        class='hover:-translate-y-1 transition-transform duration-100 p-1'
+        href='https://www.instagram.com/pete.pittawat/'
+        target='_blank'
+      >
+        <Instagram />
+      </a>
+      <a
+        class='hover:-translate-y-1 transition-transform duration-100 p-1'
+        href='https://scholar.google.co.jp/citations?user=2CFoP9cAAAAJ&hl=en'
+        target='_blank'
+      >
+        Google Scholar
+      </a>
+      <a
+        class='hover:-translate-y-1 transition-transform duration-100 p-1'
+        href='https://orcid.org/0000-0002-6824-2634'
+        target='_blank'
+      >
+        ORCID
+      </a>
+    </div>
 		<p>
 			Hey! I'm Pittawat Taveekitworachai, but you can just call me <strong
 				>Pete</strong

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogListPage from '../../components/BlogListPage';
+import PageHeader from '../../components/PageHeader.astro';
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
@@ -19,7 +20,8 @@ const tags = [
 ---
 
 <BaseLayout title={`${SITE_TITLE} - Blog`} description={SITE_DESCRIPTION}>
-	<BlogListPage client:load posts={posts} tags={tags} />
+  <PageHeader title="Blog" subtitle="Thoughts, ideas, and updates" />
+  <BlogListPage client:load posts={posts} tags={tags} />
 </BaseLayout>
 
 <!-- Removed column-span styling now that list uses CSS grid -->

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -4,6 +4,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import Divider from '../components/Divider.astro';
 import PublicationsExplorer from '../components/PublicationsExplorer.tsx';
 import publications from '../content/publications/publications.json';
+import PageHeader from '../components/PageHeader.astro';
 
 type Publication = {
   year: number;
@@ -23,11 +24,11 @@ type Publication = {
   title={`${SITE_TITLE} - Publications`}
   description={SITE_DESCRIPTION}
 >
-  <section class='prose dark:prose-invert md:prose-lg mx-auto prose-a:text-[color:var(--accent)]'>
-    <h1>Publications</h1>
-    <p class='italic'>Search, filter by type, year, and tags. Links to code/data are provided when available.</p>
-    <Divider />
-  </section>
+  <PageHeader
+    title="Publications"
+    subtitle="Search, filter by type, year, and tags. Links to code/data are provided when available."
+  />
+  <Divider />
   <section class='mx-auto mt-4 max-w-4xl'>
     <PublicationsExplorer client:load items={publications} />
   </section>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -3,6 +3,7 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TalksExplorer from '../components/TalksExplorer.tsx';
 import talks from '../content/talks/talks.json';
+import PageHeader from '../components/PageHeader.astro';
 
 type Talk = {
   date: string;
@@ -18,12 +19,10 @@ type Talk = {
 ---
 
 <BaseLayout title={`${SITE_TITLE} - Talks`} description={SITE_DESCRIPTION}>
-  <section class='mx-auto prose dark:prose-invert prose-a:text-[color:var(--accent)] hyphens-auto md:prose-lg'>
-    <p>
-      Throughout the years, I have regularly shared my knowledge through talks or lectures at various venues, including for my lab
-      peers, conferences, and communities. Explore my talks and lectures below, with search and filters.
-    </p>
-  </section>
+  <PageHeader
+    title="Talks"
+    subtitle="Talks and lectures at conferences, labs, and communities. Search and filter below."
+  />
   <section class='mx-auto mt-4 max-w-4xl'>
     <TalksExplorer client:load items={talks} />
   </section>


### PR DESCRIPTION
## Summary
- add reusable PageHeader component with conic-gradient blur background
- use PageHeader on Blog, Publications, Talks, and About pages

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6896f2bac9b083258bcd804656ea239f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visually enhanced, reusable page header component with customizable titles and subtitles across multiple pages.

* **Refactor**
  * Replaced existing manual headers on About, Blog, Publications, and Talks pages with the new page header component for a consistent look and improved design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->